### PR TITLE
Fix broken icon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src='https://rawgithub.com/FortAwesome/Font-Awesome/master/advanced-options/raw-svg/solid/brain.svg' card_color='#FD9E66' width='50' height='50' style='vertical-align:bottom'/> Recommendations Fallback Skill
+# <img src='https://rawgit.com/FortAwesome/Font-Awesome/master/svgs/solid/brain.svg' card_color='#FD9E66' width='50' height='50' style='vertical-align:bottom'/> Recommendations Fallback Skill
 When Mycroft doesn't know something, he will look up and download a skill that can handle that utterance.
 
 ## About 


### PR DESCRIPTION
There was a broken link to the icon for the Skill; fixes the broken link. 
This was because FortAwesome changed their directory structure on GitHub.com